### PR TITLE
Fix NO_MAGIC_PLOT_VALUE import 

### DIFF
--- a/gatling-charts-highcharts/src/main/scala/com/excilys/ebi/gatling/highcharts/series/ResponseTimeSeries.scala
+++ b/gatling-charts-highcharts/src/main/scala/com/excilys/ebi/gatling/highcharts/series/ResponseTimeSeries.scala
@@ -6,7 +6,7 @@
 package com.excilys.ebi.gatling.highcharts.series
 
 import com.excilys.ebi.gatling.charts.series.Series
-import com.excilys.ebi.gatling.charts.util.StatisticsHelper.NO_PLOT_MAGIC_VALUE
+import com.excilys.ebi.gatling.core.result.reader.DataReader.NO_PLOT_MAGIC_VALUE
 
 class ResponseTimeSeries(name: String, data: Seq[(Long, Long)], color: String) extends Series[Long, Long](name, data, List(color)) {
 


### PR DESCRIPTION
Change import of NO_MAGIC_PLOT_VALUE due to refactoring in gatling-charts and gatling-core.

This change is linked to the total rework of log processing. It must be taken into account after the pull request "Complete rework of log processing : use scalding to generate reports" on excilys/gatling.
