### PR TITLE
Use sbt-pgp's publishSigned task in sbt-release release process

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -5,9 +5,7 @@ import com.typesafe.sbt.SbtScalariform
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import net.virtualvoid.sbt.graph.Plugin.graphSettings
 import com.typesafe.sbteclipse.plugin.EclipsePlugin._
-import sbtrelease.ReleasePlugin._
 
-import Publishing._
 import Resolvers._
 
 object BuildSettings {
@@ -34,7 +32,7 @@ object BuildSettings {
 
 	lazy val gatlingHighchartsSettings = 
 		basicSettings ++ formattingSettings ++ graphSettings ++ 
-		publishingSettings ++ eclipseSettings ++ releaseSettings
+		Publish.settings ++ Release.settings ++ eclipseSettings
 
 	/*************************/
 	/** Formatting settings **/

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -3,9 +3,9 @@ import sbt.Keys._
 
 import Resolvers._
 
-object Publishing {
+object Publish {
 
-	lazy val publishingSettings = Seq(
+	lazy val settings = Seq(
 		crossPaths           := false,
 		pomExtra             := scm ++ developersXml(developers),
 		publishMavenStyle    := true,

--- a/project/Release.scala
+++ b/project/Release.scala
@@ -1,0 +1,32 @@
+import sbt._
+import sbt.Keys._
+
+import com.typesafe.sbt.SbtPgp.PgpKeys._
+import sbtrelease.ReleaseStep
+import sbtrelease.ReleasePlugin._
+import sbtrelease.ReleasePlugin.ReleaseKeys._
+
+object Release {
+
+	// Index of the 'publishArtifact' release step in release process Seq
+	private val releaseStepPublishIndex = 7
+
+	lazy val settings = releaseSettings ++ Seq(
+		crossBuild := false,
+		releaseProcess := updateReleaseStep(releaseProcess.value, releaseStepPublishIndex, usePublishSigned)
+	)
+
+	private def updateReleaseStep(releaseProcess: Seq[ReleaseStep], releaseStepIdx : Int, update: ReleaseStep => ReleaseStep) = {
+		releaseProcess.updated(releaseStepIdx, update(releaseProcess(releaseStepIdx)))
+	}
+
+	private def usePublishSigned(step: ReleaseStep) = {
+		lazy val publishSignedArtifactsAction = { st: State =>
+			val extracted = Project.extract(st)
+			val ref = extracted.get(thisProjectRef)
+			extracted.runAggregated(publishSigned in Global in ref, st)
+		}
+
+		step.copy(action = publishSignedArtifactsAction)
+	}
+}


### PR DESCRIPTION
This PR replaces the `publishArtifacts` release step of sbt-release's release process by a custom release step which uses sbt-pgp's publishSigned task.

Note : I couldn't properly test this change, since this means that I'd need to make a release.
However, this mimics as closely as possible the `publishArtifacts` release step implementation.
