### PR TITLE
Fix license URL in BuildSettings.scala

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -16,7 +16,7 @@ object BuildSettings {
     organization         := "io.gatling.highcharts",
     organizationHomepage := Some(new URL("http://gatling.io")),
     startYear            := Some(2011),
-    licenses             := Seq("Gatling Highcharts License" -> new URL("https://raw.github.com/gatling/gatling-highcharts/master/src/main/resources/META-INF/LICENCE")),
+    licenses             := Seq("Gatling Highcharts License" -> new URL("https://raw.github.com/gatling/gatling-highcharts/master/src/main/resources/META-INF/LICENSE")),
     resolvers            := envOrNone("CI").map(_ => Seq(sonatypeSnapshots)).getOrElse(Seq.empty),
     scalaVersion         := "2.10.4",
     scalacOptions        := Seq(


### PR DESCRIPTION
The following URL redirects to a non-existing file:
https://raw.github.com/gatling/gatling-highcharts/master/src/main/resources/META-INF/LICENCE

Correct URL is:
https://raw.github.com/gatling/gatling-highcharts/master/src/main/resources/META-INF/LICENSE
