### PR TITLE
Publish bundle.zip without publishing jar/javadoc/sources

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,4 +35,6 @@ lazy val gatlingHighchartsBundle = gatlingHighchartsModule("gatling-charts-highc
   .enablePlugins(UniversalPlugin)
   .settings(libraryDependencies ++= gatlingHighchartsBundleDeps(version.value, scalaVersion.value))
   .settings(bundleSettings: _*)
-  .settings(publish / skip := true)
+  .settings(packageDoc / publishArtifact := false) // no javadoc
+  .settings(packageSrc / publishArtifact := false) // no source
+  .settings(packageBin / publishArtifact := false) // no jar (remains the bundle.zip)


### PR DESCRIPTION
Motivation:
The bundle MUST be published.

Modifications:
 * Do not skip publish phase for bundle
 * Do not publish jar / javadoc / sources for bundle

Result:
The bundle zip will be published during next release.