### PR TITLE
chore: Switch GitHub actions from setup-scala to setup-java

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,10 +36,11 @@ jobs:
         with:
           path: gatling-highcharts
 
-      - name: Setup Scala
-        uses: olafurpg/setup-scala@v10
+      - name: Setup JDK
+        uses: actions/setup-java@v2
         with:
-          java-version: "adopt@1.8"
+          distribution: 'zulu'
+          java-version: '8'
 
       - name: Cache SBT
         uses: actions/cache@v2

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -31,10 +31,11 @@ jobs:
           fetch-depth: 0 # indicates all history for all branches and tags
           token: ${{ secrets.GATLING_CI_TOKEN }} # for tag to trigger other workflows (release)
 
-      - name: Setup Scala
-        uses: olafurpg/setup-scala@v10
+      - name: Setup JDK
+        uses: actions/setup-java@v2
         with:
-          java-version: "adopt@1.8"
+          distribution: 'zulu'
+          java-version: '8'
 
       - name: Cache SBT
         uses: actions/cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Scala
-        uses: olafurpg/setup-scala@v10
+      - name: Setup JDK
+        uses: actions/setup-java@v2
         with:
-          java-version: "adopt@1.8"
+          distribution: 'zulu'
+          java-version: '8'
 
       - name: Prepare environment
         env:


### PR DESCRIPTION
Motivation:

See olafurpg/setup-scala#49:
- olafurpg/setup-scala is no longer considered necessary by its maintainer and will probably be archived at some point.
- Ubuntu runners now include the official SBT launcher by default.
- actions/setup-java is the official action for setting up a JDK, so we might as well use that if it"s sufficient for our purpose.

Modifications:

- Replace olafurpg/setup-scala with actions/setup-java.
- Use Zulu JDK.